### PR TITLE
loadFile: expose require.extensions

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -122,6 +122,7 @@ var loadFile = function(filePath, mocks, globals, mockNested) {
       exports: exports
     }
   };
+  context.require.extensions = require.extensions;
 
   Object.getOwnPropertyNames(globals || {}).forEach(function(name) {
     context[name] = globals[name];


### PR DESCRIPTION
Module under test may need `require.extensions` but currently it is not exposed.
