### PR TITLE
Allow fs functions to be called without fs as this arg

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -74,25 +74,7 @@ var Mock = function(structure) {
 
 
   // public API
-  this.stat = function(path, callback) {
-    var statSync = this.statSync;
-
-    predictableNextTick(function() {
-      var stat = null;
-      var error = null;
-
-      try {
-        stat = statSync(path);
-      } catch(e) {
-        error = e;
-      }
-
-      callback(error, stat);
-    });
-  };
-
-
-  this.statSync = function(path) {
+  var statSync = this.statSync = function(path) {
     validatePath(path);
 
     var pointer = getPointer(path, structure);
@@ -109,6 +91,21 @@ var Mock = function(structure) {
     return pointer instanceof File ? pointer.getStats() : new Stats(typeof pointer !== 'object');
   };
 
+
+  this.stat = function(path, callback) {
+    predictableNextTick(function() {
+      var stat = null;
+      var error = null;
+
+      try {
+        stat = statSync(path);
+      } catch(e) {
+        error = e;
+      }
+
+      callback(error, stat);
+    });
+  };
 
   this.readdir = function(path, callback) {
     validatePath(path);
@@ -146,23 +143,7 @@ var Mock = function(structure) {
   };
 
 
-  this.mkdir = function(directory, callback) {
-    var mkdirSync = this.mkdirSync;
-    var error = null;
-
-    predictableNextTick(function() {
-      try {
-        mkdirSync(directory);
-      } catch (e) {
-        error = e;
-      }
-
-      callback(error);
-    });
-  };
-
-
-  this.mkdirSync = function(directory) {
+  var mkdirSync = this.mkdirSync = function(directory) {
     var pointer = getPointer(path.dirname(directory), structure);
     var baseName = path.basename(directory);
 
@@ -179,26 +160,22 @@ var Mock = function(structure) {
   };
 
 
-  this.readFile = function(path, encoding, callback) {
-    var readFileSync = this.readFileSync;
-    callback = callback || encoding;
+  this.mkdir = function(directory, callback) {
+    var error = null;
 
     predictableNextTick(function() {
-      var data = null;
-      var error = null;
-
       try {
-        data = readFileSync(path);
-      } catch(e) {
+        mkdirSync(directory);
+      } catch (e) {
         error = e;
       }
 
-      callback(error, data);
+      callback(error);
     });
   };
 
 
-  this.readFileSync = function(path) {
+  var readFileSync = this.readFileSync = function(path) {
     var pointer = getPointer(path, structure);
     var error;
 
@@ -224,6 +201,24 @@ var Mock = function(structure) {
   };
 
 
+  this.readFile = function(path, encoding, callback) {
+    callback = callback || encoding;
+
+    predictableNextTick(function() {
+      var data = null;
+      var error = null;
+
+      try {
+        data = readFileSync(path);
+      } catch(e) {
+        error = e;
+      }
+
+      callback(error, data);
+    });
+  };
+
+
   this.writeFile = function(filePath, content, callback) {
     predictableNextTick(function() {
       var pointer = getPointer(path.dirname(filePath), structure);
@@ -241,25 +236,23 @@ var Mock = function(structure) {
   };
 
 
-  this.watchFile = function(path, options, callback) {
-    callback = callback || options;
-    watchers[path] = watchers[path] || [];
-    watchers[path].push(callback);
-  };
+  var existsSync = this.existsSync = function(path) {
+    return getPointer(path, structure) != null;
+  }
 
 
   this.exists = function(path, callback) {
-    var existsSync = this.existsSync;
-
     predictableNextTick(function() {
       callback(existsSync(path));
     });
   };
 
 
-  this.existsSync = function(path) {
-    return getPointer(path, structure) != null;
-  }
+  this.watchFile = function(path, options, callback) {
+    callback = callback || options;
+    watchers[path] = watchers[path] || [];
+    watchers[path].push(callback);
+  };
 
 
   // Mock API

--- a/test/fs.spec.coffee
+++ b/test/fs.spec.coffee
@@ -59,6 +59,17 @@ describe 'fs', ->
       waitForFinished 2
 
 
+    it 'should stat file when called without fs as this arg', ->
+      callback = (err, stat) ->
+        expect(err).toBeFalsy()
+        expect(stat.isDirectory()).toBe false
+        finished++
+
+      stat = fs.stat
+      stat '/home/vojta/some.js', callback
+      waitForFinished 1
+
+
     it 'should return error when path does not exist', ->
       callback = (err, stat) ->
         expect(err).toBeTruthy()


### PR DESCRIPTION
The node fs functions can be called without the fs module as the this argument.  This is fairly common practice with things like async:

``` js
async.map(paths, fs.stat, function(err, results) {
  ...
});
```

With this change, the mock `stat`, `mkdir`, and `readFile` functions can be called without the mock itself as the `this` arg.
