### PR TITLE
Support for encoding option in fs.readFile and fs.readFileSync

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -178,29 +178,31 @@ var Mock = function(structure) {
     throw error;
   };
 
-
-  this.readFile = function(path, encoding, callback) {
+  this.readFile = function(path, options, callback) {
     var readFileSync = this.readFileSync;
-    callback = callback || encoding;
+    if (typeof callback === 'undefined') {
+      callback = options;
+      options = null;
+    }
 
     predictableNextTick(function() {
       var data = null;
       var error = null;
 
       try {
-        data = readFileSync(path);
+        data = readFileSync(path, options);
       } catch(e) {
         error = e;
       }
-
       callback(error, data);
     });
   };
 
 
-  this.readFileSync = function(path) {
+  this.readFileSync = function(path, options) {
     var pointer = getPointer(path, structure);
-    var error;
+    var encoding = (options && options.encoding) || options;
+    var error, buffer;
 
     if (!pointer) {
       error = new Error(util.format('No such file or directory "%s"', path));
@@ -210,17 +212,22 @@ var Mock = function(structure) {
     }
 
     if (pointer instanceof File) {
-      return pointer.getBuffer();
-    }
-
-    if (typeof pointer === 'object') {
+      buffer = pointer.getBuffer();
+    } else if (typeof pointer === 'object') {
       error = new Error('Illegal operation on directory');
       error.code = 'EISDIR';
 
       throw error;
+    } else {
+      buffer = new Buffer('');
     }
 
-    return new Buffer('');
+    if (typeof encoding === 'string') {
+      var data = buffer.toString(encoding);
+      return data;
+    } else {
+      return buffer;
+    }
   };
 
 

--- a/test/fs.spec.coffee
+++ b/test/fs.spec.coffee
@@ -228,6 +228,25 @@ describe 'fs', ->
       fs.readFile '/home/vojta/some.js', callback
       waitForFinished()
 
+    it 'should read file content as string when encoding is specified', ->
+      callback = (err, data) ->
+        expect(err).toBeFalsy()
+        expect(typeof data).toBe 'string'
+        expect(data).toBe 'some'
+        finished++
+
+      fs.readFile '/home/vojta/some.js', 'utf8', callback
+      waitForFinished()
+
+    it 'should read file content as string when encoding is specified as an option', ->
+      callback = (err, data) ->
+        expect(err).toBeFalsy()
+        expect(typeof data).toBe 'string'
+        expect(data).toBe 'some'
+        finished++
+
+      fs.readFile '/home/vojta/some.js', {encoding: 'utf8'}, callback
+      waitForFinished()
 
     it 'should be async', ->
       callback = jasmine.createSpy 'calback'


### PR DESCRIPTION
A very small fix to make the encoding option work in fs.readFile and fs.readFileSync. These calls will all now return a string:

```
fs.readFile(path, 'utf8', callback);
fs.readFile(path, {encoding: 'utf8'}, callback);
fs.readFileSync(path, 'utf8');
fs.readFileSync(path, {encoding: 'utf8'});
```

I added a couple of tests, and the existing tests all pass.
