### PR TITLE
Http features

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -7,7 +7,8 @@ var ServerResponse = function() {
 
   this._headers = {};
   this._body = null;
-  this._status = null;
+  this._statusCode = null;
+  this._statusText = null;
 
   this._isFinished = function() {
     return this.headerSent && bodySent;
@@ -20,7 +21,7 @@ var ServerResponse = function() {
       throw new Error("Can't set headers after they are sent.");
     }
 
-    this._headers[name] = value;
+    this._headers[name.toLowerCase()] = value;
   };
 
   this.getHeader = function(name) {
@@ -31,13 +32,24 @@ var ServerResponse = function() {
     delete this._headers[name];
   };
 
-  this.writeHead = function(status) {
+  this.writeHead = function(status, reason, headers) {
     if (this.headerSent) {
       throw new Error("Can't render headers after they are sent to the client.");
     }
 
+    if (typeof reason === 'object') {
+      headers = reason;
+      reason = undefined;
+    }
+    headers = headers || {};
+
+    for(var name in headers) {
+      this._headers[name.toLowerCase()] = headers[name];
+    }
+
     this.headerSent = true;
-    this._status = status;
+    this._statusCode = status;
+    this._statusText = reason;
   };
 
   this.write = function(content) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -68,6 +68,14 @@ var ServerResponse = function() {
     bodySent = true;
     this.emit('end');
   };
+
+  this.getDebugData = function() {
+    return {
+      status: {code: this._statusCode, text: this._statusText},
+      header: this._headers,
+      body: this._body
+    };
+  }
 };
 
 util.inherits(ServerResponse, EventEmitter);


### PR DESCRIPTION
The `writeHead` method didn't take the arguments for status text and headers, so I added those.
Also changed the header names to be lower-case since that's how node core does it.

Oh right, and there's also the getDebugData function to get it all back since it's not usually a good idea to poke at the prefixed implementation details of an object.

I can change some of this if that's not how it's supposed to work here.
